### PR TITLE
Changed public API so pre-roll and initial mid-roll are provided in delegate.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "HLSInterstitialKit",
+    platforms: [.iOS(.v13), .tvOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/HLSInterstitialKit/Event/HLSInterstitialEventLoadingRequestDecisionHandler.swift
+++ b/Sources/HLSInterstitialKit/Event/HLSInterstitialEventLoadingRequestDecisionHandler.swift
@@ -1,3 +1,4 @@
 protocol HLSInterstitialEventLoadingRequestDecisionHandler: AnyObject {
     func shouldWaitForLoadingOfRequest(_ request: HLSInterstitialEventLoadingRequest) -> Bool
+    func shouldWaitForLoadingOfInitialRequest(_ request: HLSInterstitialEventInitialLoadingRequest) -> Bool
 }

--- a/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioner.swift
+++ b/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioner.swift
@@ -1,0 +1,70 @@
+import mamba
+
+protocol EventDecisioner {
+    func events(
+        forParameters parameters: [String: HLSInterstitialEventLoadingRequest.Parameters],
+        playlist: HLSPlaylist
+    ) async -> EventsResponse
+}
+
+struct EventsResponse {
+    let idToEventMap: [String: HLSInterstitialEvent]
+    let preRollInterstitials: [HLSInterstitialEvent]
+    let initialInterstitials: [HLSInterstitialInitialEvent]
+}
+
+/// Provides a wrapper around the decisioning actor
+///
+/// Since we need to keep a single reference for event decisions across all media playlists, and actors are value types,
+/// we need to wrap the actor in a reference type in order to provide the same actor for all media decisions.
+class HLSInterstitialEventDecisioner: EventDecisioner {
+    weak var decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?
+
+    private let decisioningActor: HLSInterstitialEventDecisioningActor
+    private let requestHandler: RequestDecisionHandler
+
+    init() {
+        let requestHandler = RequestDecisionHandler()
+        self.decisioningActor = HLSInterstitialEventDecisioningActor(decisionHandler: requestHandler)
+        self.requestHandler = requestHandler
+        requestHandler.decisionHandler = self
+    }
+
+    func events(
+        forParameters parameters: [String: HLSInterstitialEventLoadingRequest.Parameters],
+        playlist: HLSPlaylist
+    ) async -> EventsResponse {
+        await decisioningActor.events(forParameters: parameters, playlist: playlist)
+    }
+}
+
+// This is a little silly, but because the decisioning actor is an actor, meaning its properties are only accessible
+// asynchrounously, it is hard to proxy the delegate methods through as we do elsewhere. As a result, we allow for
+// setting the delegate through the initializer; however, we can't set the decisioner as the delegate as it would not be
+// fully initialized when trying to set self as delegate. So there is this strange dance here where we create a proxy
+// class just to transfer delegate methods between the actor and the container.
+extension HLSInterstitialEventDecisioner: HLSInterstitialEventLoadingRequestDecisionHandler {
+    class RequestDecisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler {
+        weak var decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?
+
+        func shouldWaitForLoadingOfRequest(_ request: HLSInterstitialEventLoadingRequest) -> Bool {
+            guard let decisionHandler = decisionHandler else { return false }
+            return decisionHandler.shouldWaitForLoadingOfRequest(request)
+        }
+
+        func shouldWaitForLoadingOfInitialRequest(_ request: HLSInterstitialEventInitialLoadingRequest) -> Bool {
+            guard let decisionHandler = decisionHandler else { return false }
+            return decisionHandler.shouldWaitForLoadingOfInitialRequest(request)
+        }
+    }
+
+    func shouldWaitForLoadingOfRequest(_ request: HLSInterstitialEventLoadingRequest) -> Bool {
+        guard let decisionHandler = decisionHandler else { return false }
+        return decisionHandler.shouldWaitForLoadingOfRequest(request)
+    }
+
+    func shouldWaitForLoadingOfInitialRequest(_ request: HLSInterstitialEventInitialLoadingRequest) -> Bool {
+        guard let decisionHandler = decisionHandler else { return false }
+        return decisionHandler.shouldWaitForLoadingOfInitialRequest(request)
+    }
+}

--- a/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioningActor.swift
+++ b/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioningActor.swift
@@ -1,0 +1,112 @@
+import Foundation
+import mamba
+
+actor HLSInterstitialEventDecisioningActor: EventDecisioner {
+    weak var decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?
+
+    /// IDs that did not have adverts provided for.
+    private var emptyIDs = [String]()
+    /// All events mapped to their corresponding IDs.
+    private var idToEventMap = [String: HLSInterstitialEvent]()
+    /// All active requests
+    private var activeRequests = [String: Task<Void, Never>]()
+    /// The initial request is handled in a special fashion as the consumer can one-time provide pre-rolls and timed
+    /// mid-roll interstitials for VOD.
+    private var initialRequestStatus = InitialRequestStatus.notStarted
+
+    init(decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler) {
+        self.decisionHandler = decisionHandler
+    }
+
+    func events(
+        forParameters parameters: [String: HLSInterstitialEventLoadingRequest.Parameters],
+        playlist: HLSPlaylist
+    ) async -> EventsResponse {
+        let isInitialRequest = !initialRequestStatus.hasStarted
+        if isInitialRequest {
+            initialRequestStatus = .inProgress
+        }
+        if Set(emptyIDs).union(Set(idToEventMap.keys)).isSuperset(of: Set(parameters.keys)) && !isInitialRequest {
+            return EventsResponse(idToEventMap: idToEventMap, initialRequestStatus: initialRequestStatus)
+        }
+        let decisionedIDs = Set(emptyIDs).union(Set(idToEventMap.keys))
+        let newParameters = parameters.values.filter { !decisionedIDs.contains($0.id) }
+        var tasksToAwait = [Task<Void, Never>]()
+        let paramsNeedingDecision: [HLSInterstitialEventLoadingRequest.Parameters] = newParameters.compactMap {
+            let id = $0.id
+            if let activeRequest = activeRequests[id] {
+                tasksToAwait.append(activeRequest)
+                return nil
+            } else {
+                return $0
+            }
+        }
+        tasksToAwait.append(
+            Task {
+                let eventHandler = HLSInterstitialEventRequestHandler(
+                    decisionHandler: decisionHandler,
+                    isInitialRequest: isInitialRequest
+                )
+                let events = await eventHandler.events(forParameters: paramsNeedingDecision, playlist: playlist)
+                for (params, event) in events.parameterizedEvents {
+                    if let event = event {
+                        idToEventMap[params.id] = event
+                    } else {
+                        emptyIDs.append(params.id)
+                    }
+                }
+                if isInitialRequest {
+                    initialRequestStatus = .completed(
+                        InitialInterstials(
+                            preRollInterstitials: events.preRollInterstitials,
+                            initialInterstitials: events.midRollInterstiitals
+                        )
+                    )
+                }
+            }
+        )
+        for task in tasksToAwait {
+            await task.value
+        }
+        return EventsResponse(idToEventMap: idToEventMap, initialRequestStatus: initialRequestStatus)
+    }
+}
+
+extension HLSInterstitialEventDecisioningActor {
+    struct InitialInterstials {
+        let preRollInterstitials: [HLSInterstitialEvent]
+        let initialInterstitials: [HLSInterstitialInitialEvent]
+    }
+
+    enum InitialRequestStatus {
+        case notStarted
+        case inProgress
+        case completed(InitialInterstials)
+
+        var hasStarted: Bool {
+            switch self {
+            case .notStarted: return false
+            case .inProgress, .completed: return true
+            }
+        }
+
+        var initialInterstitials: InitialInterstials {
+            switch self {
+            case .notStarted, .inProgress: return InitialInterstials(preRollInterstitials: [], initialInterstitials: [])
+            case .completed(let interstitials): return interstitials
+            }
+        }
+    }
+}
+
+fileprivate extension EventsResponse {
+    init(
+        idToEventMap: [String: HLSInterstitialEvent],
+        initialRequestStatus: HLSInterstitialEventDecisioningActor.InitialRequestStatus
+    ) {
+        let initialInterstitials = initialRequestStatus.initialInterstitials
+        self.idToEventMap = idToEventMap
+        self.preRollInterstitials = initialInterstitials.preRollInterstitials
+        self.initialInterstitials = initialInterstitials.initialInterstitials
+    }
+}

--- a/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventRequestHandler.swift
+++ b/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventRequestHandler.swift
@@ -1,0 +1,135 @@
+import mamba
+
+actor HLSInterstitialEventRequestHandler: HLSInterstitialEventLoadingRequestDelegate {
+    private weak var decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?
+    private let isInitialRequest: Bool
+    private var loadingRequests = [
+        HLSInterstitialEventLoadingRequest: CheckedContinuation<ParameterizedEvents, Never>
+    ]()
+
+    init(
+        decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?,
+        isInitialRequest: Bool
+    ) {
+        self.decisionHandler = decisionHandler
+        self.isInitialRequest = isInitialRequest
+    }
+
+    func events(
+        forParameters parameters: [HLSInterstitialEventLoadingRequest.Parameters],
+        playlist: HLSPlaylist
+    ) async -> ParameterizedEvents {
+        guard let decisionHandler = decisionHandler else { return emptyResponse(fromParameters: parameters) }
+        if parameters.isEmpty && !isInitialRequest {
+            return emptyResponse(fromParameters: parameters)
+        }
+        if isInitialRequest {
+            let eventRequest = HLSInterstitialEventInitialLoadingRequest(
+                parameters: parameters,
+                playlist: playlist,
+                delegate: self
+            )
+            return await withCheckedContinuation { continuation in
+                Task {
+                    loadingRequests[eventRequest] = continuation
+                    guard decisionHandler.shouldWaitForLoadingOfInitialRequest(eventRequest) else {
+                        loadingRequestCancelled(request: eventRequest)
+                        return
+                    }
+                }
+            }
+        } else {
+            let eventRequest = HLSInterstitialEventLoadingRequest(
+                parameters: parameters,
+                playlist: playlist,
+                delegate: self
+            )
+            return await withCheckedContinuation { continuation in
+                Task {
+                    loadingRequests[eventRequest] = continuation
+                    guard decisionHandler.shouldWaitForLoadingOfRequest(eventRequest) else {
+                        loadingRequestCancelled(request: eventRequest)
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    nonisolated func interstitialEventLoadingRequest(
+        _ request: HLSInterstitialEventLoadingRequest,
+        didFinishLoadingWithResult result: HLSInterstitialEventLoadingRequestResult,
+        preRollInterstitials: [HLSInterstitialEvent],
+        midRollInterstiitals: [HLSInterstitialInitialEvent]
+    ) {
+        Task {
+            switch result {
+            case .success(let events):
+                await loadingRequestCompleted(
+                    request: request,
+                    events: events,
+                    preRollInterstitials: preRollInterstitials,
+                    midRollInterstiitals: midRollInterstiitals
+                )
+            case .failure:
+                await loadingRequestCancelled(request: request)
+            }
+        }
+    }
+
+    nonisolated func interstitialEventLoadingRequestDidGetCancelled(_ request: HLSInterstitialEventLoadingRequest) {
+        Task {
+            await loadingRequestCancelled(request: request)
+        }
+    }
+
+    private func loadingRequestCompleted(
+        request: HLSInterstitialEventLoadingRequest,
+        events: [HLSInterstitialEventLoadingRequest.Parameters: HLSInterstitialEvent?],
+        preRollInterstitials: [HLSInterstitialEvent],
+        midRollInterstiitals: [HLSInterstitialInitialEvent]
+    ) {
+        guard let continuation = loadingRequests[request] else { return }
+        loadingRequests.removeValue(forKey: request)
+        // Just ensuring that only requested parameters are provided by delegate, and that we have a response for each.
+        let events = request.parameters.reduce(
+            into: [HLSInterstitialEventLoadingRequest.Parameters: HLSInterstitialEvent?]()
+        ) {
+            $0[$1] = events[$1]
+        }
+        continuation.resume(
+            returning: ParameterizedEvents(
+                parameterizedEvents: events,
+                preRollInterstitials: preRollInterstitials,
+                midRollInterstiitals: midRollInterstiitals
+            )
+        )
+    }
+
+    private func loadingRequestCancelled(request: HLSInterstitialEventLoadingRequest) {
+        guard let continuation = loadingRequests[request] else { return }
+        loadingRequests.removeValue(forKey: request)
+        continuation.resume(returning: emptyResponse(fromParameters: request.parameters))
+    }
+
+    private func emptyResponse(
+        fromParameters parameters: [HLSInterstitialEventLoadingRequest.Parameters]
+    ) -> ParameterizedEvents {
+        let events = parameters.reduce(into: [HLSInterstitialEventLoadingRequest.Parameters: HLSInterstitialEvent?]()) {
+            $0[$1] = nil
+        }
+        return ParameterizedEvents(
+            parameterizedEvents: events,
+            preRollInterstitials: [],
+            midRollInterstiitals: []
+        )
+    }
+}
+
+extension HLSInterstitialEventRequestHandler {
+    struct ParameterizedEvents {
+        let parameterizedEvents: [HLSInterstitialEventLoadingRequest.Parameters: HLSInterstitialEvent?]
+        let preRollInterstitials: [HLSInterstitialEvent]
+        let midRollInterstiitals: [HLSInterstitialInitialEvent]
+    }
+}

--- a/Sources/HLSInterstitialKit/HLSInterstitialAsset.swift
+++ b/Sources/HLSInterstitialKit/HLSInterstitialAsset.swift
@@ -28,17 +28,6 @@ public final class HLSInterstitialAsset: AVURLAsset {
         )
     }
     
-    public convenience init(
-        url: URL,
-        options: [String : Any]? = nil,
-        initialEvents: [HLSInterstitialInitialEvent],
-        preRollInterstitials: [HLSInterstitialEvent]
-    ) {
-        self.init(url: url, options: options)
-        resourceLoaderDelegate.initialEvents = initialEvents
-        resourceLoaderDelegate.preRollInterstitials = preRollInterstitials
-    }
-    
     override public func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,
@@ -59,5 +48,9 @@ public final class HLSInterstitialAsset: AVURLAsset {
 extension HLSInterstitialAsset: HLSInterstitialEventLoadingRequestDecisionHandler {
     func shouldWaitForLoadingOfRequest(_ request: HLSInterstitialEventLoadingRequest) -> Bool {
         return delegate?.interstitialAsset(self, shouldWaitForLoadingOfRequest: request) ?? false
+    }
+
+    func shouldWaitForLoadingOfInitialRequest(_ request: HLSInterstitialEventInitialLoadingRequest) -> Bool {
+        return delegate?.interstitialAsset(self, shouldWaitForLoadingOfInitialRequest: request) ?? false
     }
 }

--- a/Sources/HLSInterstitialKit/HLSInterstitialAssetDelegate.swift
+++ b/Sources/HLSInterstitialKit/HLSInterstitialAssetDelegate.swift
@@ -1,8 +1,64 @@
 import Foundation
 
 public protocol HLSInterstitialAssetDelegate: AnyObject {
+    /// Asks the delegate if it wants to handle the request.
+    ///
+    /// The asset calls this method when assistance is required of your code to load the potential interstitial event.
+    /// For example, the asset might call this method when an EXT-X-DATERANGE tag is found in the playlist, with
+    /// SCTE35-OUT attribute having valid SCTE-35 information that potentially indicates an ad insertion opportunity.
+    ///
+    /// Each interstitial event request parameters will only ever be requested for loading once.
+    ///
+    /// Returning `true` from this method, implies only that the receiver will load, or at least attempt to load, the
+    /// interstitial event information. In some implementations, the actual work of loading the resource might be
+    /// initiated on another thread, running asynchronously to the asset delegate; whether the work begins immediately
+    /// or merely soon is an implementation detail of the client application.
+    ///
+    /// You can load the resource synchronously or asynchronously. In both cases, you must indicate success or failure
+    /// of the operation by calling the finishLoading(withResult:) or cancel() method of the request object when you
+    /// finish.
+    ///
+    /// **NOTE:** If loading synchronously, do not use `DispatchSemaphore`, as internally the `HLSInterstitialAsset` is
+    /// making use of Swift Concurrency while waiting for responses, which does not function well with semaphores.
+    ///
+    /// If you return `false` from this method, the asset treats the loading of request parameters as having failed.
+    /// - Parameters:
+    ///   - asset: The asset making the request.
+    ///   - request: The request object that contains information about the requested event parameters.
+    /// - Returns: `true` if your delegate can load the resource specified by the loadingRequest parameter or `false` if
+    /// it cannot.
     func interstitialAsset(
         _ asset: HLSInterstitialAsset,
         shouldWaitForLoadingOfRequest request: HLSInterstitialEventLoadingRequest
+    ) -> Bool
+
+    /// Asks the delegate if it wants to handle the first request.
+    ///
+    /// This method is much the same as `interstitialAsset(_:shouldWaitForLoadingOfRequest)`, except that this request
+    /// is only ever made once at the start of playback, and is where the application code can provide pre-roll
+    /// interstitial events or manually timed interstitial events (not constrained to an EXT-X-DATERANGE tag). The
+    /// `request.playlist` parameter can provide additional context on what playlist the insertion is being made into.
+    ///
+    /// Returning `true` from this method, implies only that the receiver will load, or at least attempt to load, the
+    /// interstitial event information. In some implementations, the actual work of loading the resource might be
+    /// initiated on another thread, running asynchronously to the asset delegate; whether the work begins immediately
+    /// or merely soon is an implementation detail of the client application.
+    ///
+    /// You can load the resource synchronously or asynchronously. In both cases, you must indicate success or failure
+    /// of the operation by calling the finishLoading(withResult:) or cancel() method of the request object when you
+    /// finish.
+    ///
+    /// **NOTE:** If loading synchronously, do not use `DispatchSemaphore`, as internally the `HLSInterstitialAsset` is
+    /// making use of Swift Concurrency while waiting for responses, which does not function well with semaphores.
+    ///
+    /// If you return `false` from this method, the asset treats the loading of request parameters as having failed.
+    /// - Parameters:
+    ///   - asset: The asset making the request.
+    ///   - request: The request object that contains information about the requested event parameters.
+    /// - Returns: `true` if your delegate can load the resource specified by the loadingRequest parameter or `false` if
+    /// it cannot.
+    func interstitialAsset(
+        _ asset: HLSInterstitialAsset,
+        shouldWaitForLoadingOfInitialRequest request: HLSInterstitialEventInitialLoadingRequest
     ) -> Bool
 }

--- a/Sources/HLSInterstitialKit/HLSInterstitialAssetResourceLoaderDelegate.swift
+++ b/Sources/HLSInterstitialKit/HLSInterstitialAssetResourceLoaderDelegate.swift
@@ -10,8 +10,6 @@ class HLSInterstitialAssetResourceLoaderDelegate: NSObject, AVAssetResourceLoade
     }
     
     let playlistLoader: HLSInterstitialPlaylistLoader
-    var initialEvents = [HLSInterstitialInitialEvent]()
-    var preRollInterstitials = [HLSInterstitialEvent]()
 
     init(playlistLoader: HLSInterstitialPlaylistLoader = HLSInterstitialPlaylistLoader()) {
         self.playlistLoader = playlistLoader
@@ -32,12 +30,7 @@ class HLSInterstitialAssetResourceLoaderDelegate: NSObject, AVAssetResourceLoade
         shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
     ) -> Bool {
         if let url = loadingRequest.request.url, url.isInterstitialURL() {
-            playlistLoader.loadPlaylist(
-                forRequest: loadingRequest.request,
-                interstitialURL: url,
-                initialInterstitials: initialEvents,
-                preRollInterstitials: preRollInterstitials
-            ) { result in
+            playlistLoader.loadPlaylist(forRequest: loadingRequest.request, interstitialURL: url) { result in
                 switch result {
                 case .success(let playlistData):
                     loadingRequest.dataRequest?.respond(with: playlistData)


### PR DESCRIPTION
This change is made because it was difficult to have context of what kind of asset (VOD vs live) was being loaded when providing pre-roll interstitials (which is important as the resume offset should be indefinite for live and zero for VOD).

As part of this change I also introduced a new (hopefully more robust) way of handling event decisioning. This new method makes use of Swift Concurrency and so the minimum target of the package has been bumped to v13. Swift Concurrency was chosen as there is a decent amount of asynchronous waiting going on while making insertions into the manifest in response to AVFoundation loading requests, and Swift Concurrency makes handling these journeys much more convenient.