### PR TITLE
Implement X-ASSET-LIST handling for iOS 16.1+

### DIFF
--- a/ReferenceApp/ReferenceApp/AdvertService.swift
+++ b/ReferenceApp/ReferenceApp/AdvertService.swift
@@ -10,20 +10,34 @@ import AVFoundation
 import HLSInterstitialKit
 
 class AdvertService {
-    private let adDuration = 15.0
-    private let urls = [
-        URL(string: "https://akam.daps.nbcuni.com/m/1/169843/19/11616659/015K831ANW12021H_ENT_MEZZ_HULU_3318934_730/master_cmaf.m3u8")!,
-        URL(string: "https://akam.daps.nbcuni.com/m/1/169843/71/11616583/015K601GON12021H_ENT_MEZZ_HULU_3318920_730/master_cmaf.m3u8")!
+    private let assets = [
+        HLSInterstitialEvent.Asset(
+            url: URL(string: "https://akam.daps.nbcuni.com/m/1/169843/19/11616659/015K831ANW12021H_ENT_MEZZ_HULU_3318934_730/master_cmaf.m3u8")!,
+            duration: 15
+        ),
+        HLSInterstitialEvent.Asset(
+            url: URL(string: "https://akam.daps.nbcuni.com/m/1/169843/71/11616583/015K601GON12021H_ENT_MEZZ_HULU_3318920_730/master_cmaf.m3u8")!,
+            duration: 15
+        )
     ]
-    private let preRollURLs = [
-        URL(string: "https://akam.daps.nbcuni.com/m/1/169843/104/11614952/030G831NBC11021H_ENT_MEZZ_HULU_3318615_730/master_cmaf.m3u8")!,
-        URL(string: "https://akam.daps.nbcuni.com/m/1/169843/19/11616659/015K831ANW12021H_ENT_MEZZ_HULU_3318934_730/master_cmaf.m3u8")!,
-        URL(string: "https://akam.daps.nbcuni.com/m/1/169843/71/11616583/015K601GON12021H_ENT_MEZZ_HULU_3318920_730/master_cmaf.m3u8")!
+    private let preRollAssets = [
+        HLSInterstitialEvent.Asset(
+            url: URL(string: "https://akam.daps.nbcuni.com/m/1/169843/104/11614952/030G831NBC11021H_ENT_MEZZ_HULU_3318615_730/master_cmaf.m3u8")!,
+            duration: 30
+        ),
+        HLSInterstitialEvent.Asset(
+            url: URL(string: "https://akam.daps.nbcuni.com/m/1/169843/19/11616659/015K831ANW12021H_ENT_MEZZ_HULU_3318934_730/master_cmaf.m3u8")!,
+            duration: 15
+        ),
+        HLSInterstitialEvent.Asset(
+            url: URL(string: "https://akam.daps.nbcuni.com/m/1/169843/71/11616583/015K601GON12021H_ENT_MEZZ_HULU_3318920_730/master_cmaf.m3u8")!,
+            duration: 15
+        )
     ]
 
     func getInterstitialPreRoll() -> HLSInterstitialEvent {
         HLSInterstitialEvent(
-            urls: preRollURLs,
+            assets: preRollAssets,
             restrictions: [.restrictJump, .restrictSkip],
             cue: .joinCue
         )
@@ -31,7 +45,7 @@ class AdvertService {
     
     func getInterstitialEvent(forDuration duration: TimeInterval, resumeOffset: TimeInterval? = nil) -> HLSInterstitialEvent {
         HLSInterstitialEvent(
-            urls: getAdURLs(forDuration: duration),
+            assets: getAdAssets(forDuration: duration),
             resumeOffset: resumeOffset,
             restrictions: [.restrictJump, .restrictSkip]
         )
@@ -47,7 +61,7 @@ class AdvertService {
             primaryItem: primaryItem,
             identifier: "\(time) (\(duration))",
             time: CMTime(seconds: time, preferredTimescale: 1),
-            templateItems: getAdURLs(forDuration: duration).map { AVPlayerItem(url: $0) },
+            templateItems: getAdAssets(forDuration: duration).map { AVPlayerItem(url: $0.url) },
             restrictions: [.constrainsSeekingForwardInPrimaryContent, .requiresPlaybackAtPreferredRateForAdvancement],
             resumptionOffset: resumeOffset.map { CMTime(seconds: $0, preferredTimescale: 1) } ?? .indefinite
         )
@@ -63,7 +77,7 @@ class AdvertService {
             primaryItem: primaryItem,
             identifier: "\(date) (\(duration))",
             date: date,
-            templateItems: getAdURLs(forDuration: duration).map { AVPlayerItem(url: $0) },
+            templateItems: getAdAssets(forDuration: duration).map { AVPlayerItem(url: $0.url) },
             restrictions: [.constrainsSeekingForwardInPrimaryContent, .requiresPlaybackAtPreferredRateForAdvancement],
             resumptionOffset: resumeOffset.map { CMTime(seconds: $0, preferredTimescale: 1) } ?? .indefinite
         )
@@ -74,7 +88,7 @@ class AdvertService {
             primaryItem: primaryItem,
             identifier: "Interstitial PreRoll Event",
             time: .zero,
-            templateItems: preRollURLs.map { AVPlayerItem(url: $0) }
+            templateItems: preRollAssets.map { AVPlayerItem(url: $0.url) }
         )
         if #available(iOS 16, tvOS 16, *) {
             event.cue = .joinCue
@@ -82,13 +96,19 @@ class AdvertService {
         return event
     }
     
-    private func getAdURLs(forDuration duration: TimeInterval) -> [URL] {
-        let durationPlusOne = duration + 1 // Give a little space for over-filling by a small amount.
-        let numberOfAds = Int(durationPlusOne / adDuration)
-        var adURLs = [URL]()
-        for index in 0..<numberOfAds {
-            adURLs.append(urls[index % 2])
+    private func getAdAssets(forDuration duration: TimeInterval) -> [HLSInterstitialEvent.Asset] {
+        var durationLeft = duration + 1 // Give a little space for over-filling by a small amount.
+        var adAssets = [HLSInterstitialEvent.Asset]()
+        var count = -1
+        while durationLeft > 0 {
+            count += 1
+            let asset = assets[count % 2]
+            durationLeft -= asset.duration
+            if durationLeft < 0 {
+                break
+            }
+            adAssets.append(asset)
         }
-        return adURLs
+        return adAssets
     }
 }

--- a/ReferenceApp/ReferenceApp/InterstitialKitViewController.swift
+++ b/ReferenceApp/ReferenceApp/InterstitialKitViewController.swift
@@ -69,7 +69,7 @@ extension InterstitialKitViewController: HLSInterstitialAssetDelegate {
         switch request.playlist.playlistType {
         case .vod:
             preRolls = HLSInterstitialEvent(
-                urls: preRolls.urls,
+                assets: preRolls.assets,
                 resumeOffset: .zero,
                 snap: preRolls.snap,
                 playoutDurationLimit: preRolls.playoutDurationLimit,

--- a/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioner.swift
+++ b/Sources/HLSInterstitialKit/EventDecisioner/HLSInterstitialEventDecisioner.swift
@@ -5,6 +5,8 @@ protocol EventDecisioner {
         forParameters parameters: [String: HLSInterstitialEventLoadingRequest.Parameters],
         playlist: HLSPlaylist
     ) async -> EventsResponse
+
+    func event(forId id: String) async -> HLSInterstitialEvent?
 }
 
 struct EventsResponse {
@@ -15,8 +17,9 @@ struct EventsResponse {
 
 /// Provides a wrapper around the decisioning actor
 ///
-/// Since we need to keep a single reference for event decisions across all media playlists, and actors are value types,
-/// we need to wrap the actor in a reference type in order to provide the same actor for all media decisions.
+/// Actor types are reference types so we don't technically need to wrap the actor in a class; however, this class still
+/// has usefulness, as it provides a synchronous (non-isolated) way to access the `decisionHandler` property (which is
+/// useful as properties are not allowed to be non-isolated).
 class HLSInterstitialEventDecisioner: EventDecisioner {
     weak var decisionHandler: HLSInterstitialEventLoadingRequestDecisionHandler?
 
@@ -35,6 +38,10 @@ class HLSInterstitialEventDecisioner: EventDecisioner {
         playlist: HLSPlaylist
     ) async -> EventsResponse {
         await decisioningActor.events(forParameters: parameters, playlist: playlist)
+    }
+
+    func event(forId id: String) async -> HLSInterstitialEvent? {
+        await decisioningActor.event(forId: id)
     }
 }
 

--- a/Sources/HLSInterstitialKit/HLSInterstitialAssetResourceLoaderDelegate.swift
+++ b/Sources/HLSInterstitialKit/HLSInterstitialAssetResourceLoaderDelegate.swift
@@ -30,6 +30,18 @@ class HLSInterstitialAssetResourceLoaderDelegate: NSObject, AVAssetResourceLoade
         shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
     ) -> Bool {
         if let url = loadingRequest.request.url, url.isInterstitialURL() {
+            if url.isAssetListURL {
+                playlistLoader.loadAssetListResponse(url: url) { result in
+                    switch result {
+                    case .success(let assetListData):
+                        loadingRequest.dataRequest?.respond(with: assetListData)
+                        loadingRequest.finishLoading()
+                    case .failure(let error):
+                        loadingRequest.finishLoading(with: error)
+                    }
+                }
+                return true
+            }
             playlistLoader.loadPlaylist(forRequest: loadingRequest.request, interstitialURL: url) { result in
                 switch result {
                 case .success(let playlistData):

--- a/Sources/HLSInterstitialKit/PlaylistHandling/AssetListResponse.swift
+++ b/Sources/HLSInterstitialKit/PlaylistHandling/AssetListResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct AssetListResponse: Encodable {
+    let assets: [HLSInterstitialEvent.Asset]
+
+    enum CodingKeys: String, CodingKey {
+        case assets = "ASSETS"
+    }
+}

--- a/Sources/HLSInterstitialKit/PlaylistHandling/MediaPlaylistManipulator.swift
+++ b/Sources/HLSInterstitialKit/PlaylistHandling/MediaPlaylistManipulator.swift
@@ -21,6 +21,11 @@ class MediaPlaylistManipulator {
 
         return try playlist.write()
     }
+
+    func assetList(forId id: String) async -> AssetListResponse {
+        let event = await eventDecisioner.event(forId: id)
+        return event.map { AssetListResponse(assets: $0.assets) } ?? AssetListResponse(assets: [])
+    }
     
     private func addInterstitialsForVOD(playlist: inout HLSPlaylist, interstitials: [HLSInterstitialInitialEvent]) {
         // Only insert initial interstitial for VOD playlist type

--- a/Sources/HLSInterstitialKit/URLHelpers/URL+HLSInterstitial.swift
+++ b/Sources/HLSInterstitialKit/URLHelpers/URL+HLSInterstitial.swift
@@ -1,6 +1,26 @@
 import Foundation
 
 extension URL {
+    /// Base URL for X-ASSET-LIST
+    static let assetListBaseURL = URL(string: "https://asset-list/assets.json")!.toInterstitialURL()
+
+    /// Helper to determne whether this `URL` is an X-ASSET-LIST URL
+    var isAssetListURL: Bool {
+        if #available(iOS 16, tvOS 16, *) {
+            return isInterstitialURL() && host() == "asset-list" && path() == "/assets.json"
+        } else {
+            return isInterstitialURL() && host == "asset-list" && path == "/assets.json"
+        }
+    }
+
+    /// The value of the `_HLS_interstitial_id` query parameter (if it exists)
+    var hlsInterstitialId: String? {
+        URLComponents(url: self, resolvingAgainstBaseURL: true)?
+            .queryItems?
+            .first(where: { $0.name == "_HLS_interstitial_id" })?
+            .value
+    }
+
     /// Helper method to determine whether this `URL` is a `HLSInterstitialScheme` type of `URL`.
     func isInterstitialURL() -> Bool {
         guard let scheme = scheme else { return false }


### PR DESCRIPTION
As of iOS 16.1 we are able to intercept X-ASSET-LIST requests via AVAssetResourceLoaderDelegate. This allows us to use this approach instead of multiple tags each with their own X-ASSET-URI. Their may not be much benefit to this approach; however, it is more in line with how a backend server may deliver an interstitial response, and so we prefer this usage over the former to better approximate how a server driven approach may look like.

In addition, some bugs with the event decisioning actor were fixed.