### PR TITLE
Update mamba to fix Xcode 16 compilation issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/comcast/mamba.git",
-            .exact(Version(1, 5, 1))
+            .upToNextMinor(from: Version(1, 6, 0))
         ),
         .package(
             url: "https://github.com/theRealRobG/SCTE35Parser.git",

--- a/ReferenceApp/ReferenceApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ReferenceApp/ReferenceApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comcast/mamba.git",
         "state": {
           "branch": null,
-          "revision": "4d2ebb7f38ef1869b926e68f9baca02d5da659ae",
-          "version": "1.5.1"
+          "revision": "07a909bee2c5c96ad9e41a6bf6b6785b38fcb6d5",
+          "version": "1.6.0"
         }
       },
       {


### PR DESCRIPTION
There are a few compilation issues in the "RapidParser" C headers as of Xcode 16. Release [1.5.9](https://github.com/Comcast/mamba/releases/tag/1.5.9) was introduced to fix this (fix was made in https://github.com/Comcast/mamba/pull/128). Here we update to at least 1.6.0 to also support a fix for media sequence calculations with playlist delta updates.